### PR TITLE
Use implementation or api and fix buildToolsVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -22,11 +22,11 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    testCompile 'junit:junit:4.12'
-    compile 'com.google.apis:google-api-services-drive:v3-rev6-1.20.0'
+    implementation 'com.android.support:appcompat-v7:26.0.0'
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev6-1.20.0'
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2308
* **Related pull-requests:**
https://github.com/EyeSeeTea/malariapp/pull/2309
https://github.com/EyeSeeTea/dhis2-android-sdk/pull/412

###   :gear: branches 
**app**: 
       Origin: feature/fix_build_gradle_warnings Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: feature/fix_build_gradle_warnings  Target: development
**SDK**: 
       Origin: feature/fix_build_gradle_warnings Target: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Remove build.gradle warnings

### :memo: How is it being implemented?

- I have replaced compile by implementation or api
- I have upgrade  buildToolsVersion to '28.0.3'
- I have modified java plugin to java-library to use api 

Api is used to expose dependencies to consumer  https://docs.gradle.org/current/userguide/java_library_plugin.html

### :boom: How can it be tested?

Related warnings should not appear

 **Use case 1:** - Execute malaria app and should work successfully (login, pull, push, create surveys etc..) 

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
